### PR TITLE
update category to Generate from Path

### DIFF
--- a/dimensioning.inx
+++ b/dimensioning.inx
@@ -52,7 +52,7 @@
 	</param>
 	  <effect>
 	  	<effects-menu>
-	  		<submenu _name="Modify Path"/>
+	  		<submenu _name="Generate from Path"/>
 	  	</effects-menu>
 	   </effect>
     <script>


### PR DESCRIPTION
Two changes.
1. This change ensures dimension line drawn outside of points. It no longer draws a dimension line in between the two end points.
   - Probably a neater way to do this but I have tested vertical,horizontal, parallel in all four quadrants. See test image.
2. The category "Generate from Path" seems better suited because the dimensions are created from a selected path but do not modify that path. The current category is "Modify Path".

![dimensions-test-palette](https://cloud.githubusercontent.com/assets/899355/15445048/bb42afea-1f4c-11e6-896f-65ba3a5ea000.png)
